### PR TITLE
Feature/#7   latency before locking when in background

### DIFF
--- a/lib/src/widgets/app_lock.dart
+++ b/lib/src/widgets/app_lock.dart
@@ -46,7 +46,7 @@ class _AppLockState extends State<AppLock> with WidgetsBindingObserver {
   static final GlobalKey<NavigatorState> _navigatorKey = GlobalKey();
 
   bool _didUnlockForAppLaunch;
-  bool _isPaused;
+  bool _isLocked;
   bool _enabled;
 
   Timer _backgroundLockLatencyTimer;
@@ -56,7 +56,7 @@ class _AppLockState extends State<AppLock> with WidgetsBindingObserver {
     WidgetsBinding.instance.addObserver(this);
 
     this._didUnlockForAppLaunch = !this.widget.enabled;
-    this._isPaused = false;
+    this._isLocked = false;
     this._enabled = this.widget.enabled;
 
     super.initState();
@@ -69,7 +69,7 @@ class _AppLockState extends State<AppLock> with WidgetsBindingObserver {
     }
 
     if (state == AppLifecycleState.paused &&
-        (!this._isPaused && this._didUnlockForAppLaunch)) {
+        (!this._isLocked && this._didUnlockForAppLaunch)) {
       this._backgroundLockLatencyTimer =
           Timer(this.widget.backgroundLockLatency, () => this.showLockScreen());
     }
@@ -156,7 +156,7 @@ class _AppLockState extends State<AppLock> with WidgetsBindingObserver {
 
   /// Manually show the [lockScreen].
   Future<void> showLockScreen() {
-    this._isPaused = true;
+    this._isLocked = true;
     return _navigatorKey.currentState.pushNamed('/lock-screen');
   }
 
@@ -167,7 +167,7 @@ class _AppLockState extends State<AppLock> with WidgetsBindingObserver {
   }
 
   void _didUnlockOnAppPaused() {
-    this._isPaused = false;
+    this._isLocked = false;
     _navigatorKey.currentState.pop();
   }
 }

--- a/lib/src/widgets/app_lock.dart
+++ b/lib/src/widgets/app_lock.dart
@@ -17,18 +17,22 @@ import 'package:flutter/material.dart';
 /// and subsequent app pauses. This can be changed later on using `AppLock.of(context).enable();`,
 /// `AppLock.of(context).disable();` or the convenience method `AppLock.of(context).setEnabled(enabled);`
 /// using a bool argument.
+///
+/// [backgroundLockLatency] determines how much time is allowed to pass when
+/// the app is in the background state before the [lockScreen] widget should be
+/// shown upon returning. It defaults to instantly.
 class AppLock extends StatefulWidget {
   final Widget Function(Object) builder;
   final Widget lockScreen;
   final bool enabled;
-  final Duration lockInBackgroundLatency;
+  final Duration backgroundLockLatency;
 
   const AppLock({
     Key key,
     @required this.builder,
     @required this.lockScreen,
     this.enabled = true,
-    this.lockInBackgroundLatency = const Duration(seconds: 0),
+    this.backgroundLockLatency = const Duration(seconds: 0),
   }) : super(key: key);
 
   static _AppLockState of(BuildContext context) =>
@@ -45,7 +49,7 @@ class _AppLockState extends State<AppLock> with WidgetsBindingObserver {
   bool _isPaused;
   bool _enabled;
 
-  Timer _lockInBackgroundLatencyTimer;
+  Timer _backgroundLockLatencyTimer;
 
   @override
   void initState() {
@@ -66,12 +70,12 @@ class _AppLockState extends State<AppLock> with WidgetsBindingObserver {
 
     if (state == AppLifecycleState.paused &&
         (!this._isPaused && this._didUnlockForAppLaunch)) {
-      this._lockInBackgroundLatencyTimer = Timer(
-          this.widget.lockInBackgroundLatency, () => this.showLockScreen());
+      this._backgroundLockLatencyTimer =
+          Timer(this.widget.backgroundLockLatency, () => this.showLockScreen());
     }
 
     if (state == AppLifecycleState.resumed) {
-      this._lockInBackgroundLatencyTimer?.cancel();
+      this._backgroundLockLatencyTimer?.cancel();
     }
 
     super.didChangeAppLifecycleState(state);
@@ -81,7 +85,7 @@ class _AppLockState extends State<AppLock> with WidgetsBindingObserver {
   void dispose() {
     WidgetsBinding.instance.removeObserver(this);
 
-    this._lockInBackgroundLatencyTimer?.cancel();
+    this._backgroundLockLatencyTimer?.cancel();
 
     super.dispose();
   }


### PR DESCRIPTION
New feature to set the latency between when the app goes into the background and when the lock screen should be shown upon return. This addresses one of the features raised in #7.