### PR TITLE
added 'debugShowCheckedModeBanner: false' to MaterialApp

### DIFF
--- a/lib/src/widgets/app_lock.dart
+++ b/lib/src/widgets/app_lock.dart
@@ -93,6 +93,7 @@ class _AppLockState extends State<AppLock> with WidgetsBindingObserver {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
+      debugShowCheckedModeBanner: false,
       home: this.widget.enabled ? this._lockScreen : this.widget.builder(null),
       navigatorKey: _navigatorKey,
       routes: {


### PR DESCRIPTION
Thank you for your amazing work. I love this widget you have created!

I wanted to hide the debug banner, but I couldn't when I was using AppLock, because the debug banner was coming from the MaterialApp within AppLock. I have hidden it now with this PR.