### PR TITLE
Add the ability to inject theme

### DIFF
--- a/lib/src/widgets/app_lock.dart
+++ b/lib/src/widgets/app_lock.dart
@@ -26,6 +26,7 @@ class AppLock extends StatefulWidget {
   final Widget lockScreen;
   final bool enabled;
   final Duration backgroundLockLatency;
+  final ThemeData themeData;
 
   const AppLock({
     Key key,
@@ -33,6 +34,7 @@ class AppLock extends StatefulWidget {
     @required this.lockScreen,
     this.enabled = true,
     this.backgroundLockLatency = const Duration(seconds: 0),
+    this.themeData,
   }) : super(key: key);
 
   static _AppLockState of(BuildContext context) =>
@@ -101,6 +103,7 @@ class _AppLockState extends State<AppLock> with WidgetsBindingObserver {
         '/unlocked': (context) =>
             this.widget.builder(ModalRoute.of(context).settings.arguments)
       },
+      theme: widget.themeData,
     );
   }
 


### PR DESCRIPTION
Firstly, thank you for this wonderful library, it took care of all the corner cases that I was previously banging my head against.

This tiny change let's the consumer inject their app's `ThemeData` so that the `lockScreen` can be styled in accordance to the rest of the app.