### PR TITLE
Feature: allow changing backgroundLockLatency

### DIFF
--- a/example/lib/screens/my_home_page.dart
+++ b/example/lib/screens/my_home_page.dart
@@ -71,6 +71,9 @@ class _MyHomePageState extends State<MyHomePage> {
                 }
               },
             ),
+            const LatencyEditor(
+              key: Key('LatencyEditor'),
+            ),
           ],
         ),
       ),
@@ -80,5 +83,59 @@ class _MyHomePageState extends State<MyHomePage> {
         child: const Icon(Icons.add),
       ),
     );
+  }
+}
+
+class LatencyEditor extends StatefulWidget {
+  const LatencyEditor({Key? key}) : super(key: key);
+
+  @override
+  State<LatencyEditor> createState() => _LatencyEditorState();
+}
+
+class _LatencyEditorState extends State<LatencyEditor> {
+  late TextEditingController backgroundLockLatencyEditingController;
+
+  @override
+  void initState() {
+    backgroundLockLatencyEditingController = TextEditingController(text: "0");
+    super.initState();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        ElevatedButton(
+          onPressed: _setBackgroundLockLatency,
+          child: const Text('Set backgroundLockLatency to'),
+        ),
+        Padding(
+          padding: const EdgeInsets.only(left: 8.0),
+          child: ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: 20),
+            child: TextField(
+              textAlign: TextAlign.right,
+              controller: backgroundLockLatencyEditingController,
+            ),
+          ),
+        ),
+        const Text('s'),
+      ],
+    );
+  }
+
+  void _setBackgroundLockLatency() {
+    try {
+      int latencyInSeconds =
+          int.parse(backgroundLockLatencyEditingController.text);
+      AppLock.of(context)?.backgroundLockLatency =
+          Duration(seconds: latencyInSeconds);
+    } catch (e) {
+      if (kDebugMode) {
+        print(e);
+      }
+    }
   }
 }

--- a/lib/src/widgets/app_lock.dart
+++ b/lib/src/widgets/app_lock.dart
@@ -53,6 +53,8 @@ class _AppLockState extends State<AppLock> with WidgetsBindingObserver {
   late bool _isLocked;
   late bool _enabled;
 
+  late Duration backgroundLockLatency;
+
   Timer? _backgroundLockLatencyTimer;
 
   @override
@@ -62,6 +64,8 @@ class _AppLockState extends State<AppLock> with WidgetsBindingObserver {
     _didUnlockForAppLaunch = !widget.enabled;
     _isLocked = false;
     _enabled = widget.enabled;
+
+    backgroundLockLatency = widget.backgroundLockLatency;
 
     super.initState();
   }
@@ -75,7 +79,7 @@ class _AppLockState extends State<AppLock> with WidgetsBindingObserver {
     if (state == AppLifecycleState.paused &&
         (!_isLocked && _didUnlockForAppLaunch)) {
       _backgroundLockLatencyTimer =
-          Timer(widget.backgroundLockLatency, () => showLockScreen());
+          Timer(backgroundLockLatency, () => showLockScreen());
     }
 
     if (state == AppLifecycleState.resumed) {


### PR DESCRIPTION
Small feature suggestion: Allow to change the backgroundLockLatency during runtime. 

Possible usecase for that: You're using a zero-latency app lock, but want to use a file picker, which puts the app in background. On return from the file picker the user should not have to enter a pin, unless maybe after a certain timeout, which would require changing backgroundLockLatency before and after using the file picker.

A relatively minor change to app_lock.dart, and I've added a possibility to test it in the example app.