### PR TITLE
Fix: _history.isNotEmpty when `enabled` parameter changes at runtime

### DIFF
--- a/lib/src/widgets/app_lock.dart
+++ b/lib/src/widgets/app_lock.dart
@@ -52,6 +52,7 @@ class _AppLockState extends State<AppLock> with WidgetsBindingObserver {
   late bool _didUnlockForAppLaunch;
   late bool _isLocked;
   late bool _enabled;
+  late bool _initiallyEnabled;
 
   Timer? _backgroundLockLatencyTimer;
 
@@ -62,6 +63,7 @@ class _AppLockState extends State<AppLock> with WidgetsBindingObserver {
     _didUnlockForAppLaunch = !widget.enabled;
     _isLocked = false;
     _enabled = widget.enabled;
+    _initiallyEnabled = widget.enabled;
 
     super.initState();
   }
@@ -98,7 +100,7 @@ class _AppLockState extends State<AppLock> with WidgetsBindingObserver {
   Widget build(BuildContext context) {
     return MaterialApp(
       debugShowCheckedModeBanner: false,
-      home: widget.enabled ? _lockScreen : widget.builder(null),
+      home: _initiallyEnabled ? _lockScreen : widget.builder(null),
       navigatorKey: _navigatorKey,
       routes: {
         '/lock-screen': (context) => _lockScreen,


### PR DESCRIPTION
Small fix resolving an issue that leads to app crashes in the case of a change to the parameter `enabled` at runtime.

Currently changing the value of `enabled` from `false` to `true` at runtime leads to a black screen due to the home page being changed while the navigator's history is non-empty. To prohibit changes to the home page when the navigator's history is non-empty, on initialisation an additional variable is introduced.